### PR TITLE
Fix bug #35.

### DIFF
--- a/lib/base/commands.rb
+++ b/lib/base/commands.rb
@@ -136,7 +136,12 @@ module Commands
     # People should work on local branches, but especially for single commit
     # changes, more often than not, they don't. Therefore we create a branch for
     # them, to be able to use code review the way it is intended.
-    if @original_branch == target_branch
+    if target_branch_defined?
+      create_new_branch = (@original_branch == target_branch) || (@original_branch == 'master')
+    else
+      create_new_branch = @original_branch == target_branch
+    end
+    if create_new_branch
       # Unless a branch name is already provided, ask for one.
       if (branch_name = @args.shift).nil?
         puts 'Please provide a name for the branch:'

--- a/lib/base/internals.rb
+++ b/lib/base/internals.rb
@@ -240,6 +240,10 @@ module Internals
     ENV['TARGET_BRANCH'] || 'master'
   end
 
+  # Returns a boolean stating if custom TARGET_BRANCH is defined.
+  def target_branch_defined?
+    !ENV['TARGET_BRANCH'].nil?
+  end
 
   # Returns a string consisting of target repo and branch.
   def target

--- a/spec/base/commands_spec.rb
+++ b/spec/base/commands_spec.rb
@@ -218,6 +218,14 @@ describe 'git review <COMMAND>' do
       subject.prepare
     end
 
+    it 'creates a local branch when TARGET_BRANCH is defined' do
+      assume_on_master
+      assume_custom_target_branch_defined
+      assume_arguments feature_name
+      subject.should_receive(:git_call).with("checkout -b #{branch_name}")
+      subject.prepare
+    end
+
     it 'sanitizes provided branch names' do
       not_sanitized = 'wild stuff?'
       sanitized = 'wild_stuff'

--- a/spec/support/assumptions.rb
+++ b/spec/support/assumptions.rb
@@ -53,6 +53,10 @@ def assume_on_feature_branch
   )
 end
 
+def assume_custom_target_branch_defined
+  ENV.stub(:[]).with('TARGET_BRANCH').and_return('#{custom_target_name}')
+end
+
 def assume_on_master_then_feature_branch
   subject.stub(:git_call).with('branch').twice.and_return(
     "* master\n", " master\n* #{branch_name}\n"

--- a/spec/support/request_context.rb
+++ b/spec/support/request_context.rb
@@ -16,6 +16,7 @@ unless RSpec.world.shared_example_groups[:request]
     let(:body) { 'some body' }
     let(:feature_name) { 'some_name' }
     let(:branch_name) { "review_#{Time.now.strftime("%y%m%d")}_#{feature_name}"}
+    let(:custom_target_name) { 'custom_target_name' }
 
 
     let(:request) {


### PR DESCRIPTION
I've fixed the bug and now `prepare` command works fine even if `TARGET_BRANCH` is defined.

An additional test is included for this fix, but unfortunately I wasn't able to try the real command on my machine because of the problem described in issue #41.
