### PR TITLE
Fix #88, allow [tag] in commit message.

### DIFF
--- a/lib/git-review/local.rb
+++ b/lib/git-review/local.rb
@@ -97,14 +97,12 @@ module GitReview
 
     # Finds the correct remote for a given branch name.
     def remote_for_branch(branch_name)
-      git_call('branch -lvv').gsub('* ', '').split("\n").each do |line|
-        entries = line.split(' ')
-        next unless entries.first == branch_name
-        # Return the remote name or nil for local branches.
-        match = entries[2].match(%r(\[(.*)(\]|:)))
-        return match[1].split('/').first if match
+      remote = git_call("for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)")
+      return nil if remote.strip.empty? # no remote tracking branch
+      remote.split("\n").each do |line|
+        match = line.match(%r((.*)\/(.*)))
+        return line.split('/').first if match
       end
-      nil
     end
 
     # @return [Array<String>] all existing branches

--- a/spec/git-review/local_spec.rb
+++ b/spec/git-review/local_spec.rb
@@ -74,15 +74,17 @@ describe 'Local' do
     end
 
     it 'finds an existing remote for a branch' do
-      subject.should_receive(:git_call).with('branch -lvv').and_return(
-        "#{branch_name}     00aa0a0 [#{remote}/#{branch_name}: ahead 1] Foo Bar\n"
+      cmd = "for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)"
+      subject.should_receive(:git_call).with(cmd).and_return(
+        "#{remote}/#{branch_name}\n"
       )
       subject.remote_for_branch(branch_name).should == remote
     end
 
     it 'returns nil for a local branch without a remote' do
-      subject.should_receive(:git_call).with('branch -lvv').
-        and_return("* #{branch_name}     00aa0a0 Foo Bar\n")
+      cmd = "for-each-ref --format='%(upstream:short)' $(git symbolic-ref -q HEAD)"
+      subject.should_receive(:git_call).with(cmd).
+        and_return("\n")
       subject.remote_for_branch(branch_name).should == nil
     end
 


### PR DESCRIPTION
The git command used for finding the remote tracking branch is referenced from http://stackoverflow.com/a/9753364.
