### PR TITLE
add license to gemspec

### DIFF
--- a/git-review.gemspec
+++ b/git-review.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/b4mboo/git-review'
   s.email = 'bamberger.dominik@gmail.com'
   s.authors = ['Dominik Bamberger']
+  s.license = "MIT"
 
   s.files = %w( LICENSE )
   s.files += Dir.glob('lib/**/*')


### PR DESCRIPTION
please add license to gemspec so that automated tools can extract the license from it (for example rubygems.org).

thanks
